### PR TITLE
Add 'τ' as an alias to tau

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -115,7 +115,7 @@ It can be re-enabled again with <code>=set channel f-wolf-filter enable</code>.<
 <p>The following constants exist:</p>
 <ul>
 <li><code>pi</code>  : 3.141592... (also <code>π</code>)</li>
-<li><code>tau</code> : 6.283185... (twice pi)</li>
+<li><code>tau</code> : 6.283185... (twice pi, aso <code>τ</code>)</li>
 <li><code>e</code>   : 2.178281...</li>
 <li><code>true</code>  : 1</li>
 <li><code>false</code> : 0</li>

--- a/mathbot/calculator/calculator.py
+++ b/mathbot/calculator/calculator.py
@@ -433,9 +433,10 @@ FIXED_VALUES = {
 	'e': math.e,
 	'pi': math.pi,
 	'π': math.pi,
+	'tau': math.pi * 2,
+	'τ': math.pi * 2,
 	'i': 1j,
 	'euler_gamma': 0.577215664901,
-	'tau': math.pi * 2,
 	'true': 1,
 	'false': 0
 }


### PR DESCRIPTION
for consistency, since `π == pi`